### PR TITLE
Add PermissionManager package to schizoid

### DIFF
--- a/config/skz_common.mk
+++ b/config/skz_common.mk
@@ -42,6 +42,10 @@ $(call inherit-product, frameworks/base/data/videos/VideoPackage2.mk)
 PRODUCT_PACKAGES += \
     ParanoidWallpapers
 
+# AOKP common packages
+PRODUCT_PACKAGES += \
+    PermissionsManager
+
 # Embed SuperUser in Settings
 SUPERUSER_EMBEDDED := true
 


### PR DESCRIPTION
I might recommend moving RomComtrol out of each individual product mk file
and into this category as well. I imagine every build of schzoid would want to
include it, so why repeat?

Change-Id: I057e4971a59c21effc355daa060a755973dcbfb5
